### PR TITLE
If screening flow is not in "instantiate on load" mode, don't use the…

### DIFF
--- a/src/pages/screening/screening.hooks.tsx
+++ b/src/pages/screening/screening.hooks.tsx
@@ -97,7 +97,8 @@ export function useScreeningNavigation() {
 export function useScreeningFlow(screeningFlowId?: string, instantiateOnLoad: boolean = true) {
 	const { isImmediateSession } = useAccount();
 	const [searchParams] = useSearchParams();
-	const isSkipped = searchParams.get('skipped') === 'true';
+	// For now - if not in "on load" mode, ignore the concept of "skipped"
+	const isSkipped = instantiateOnLoad ? searchParams.get('skipped') === 'true' : false;
 	const [didCheckScreeningSessions, setDidCheckScreeningSessions] = useState(!screeningFlowId || isSkipped);
 	const [screeningSessions, setScreeningSessions] = useState<ScreeningSession[]>([]);
 	const [showPhoneModal, setShowPhoneModal] = useState(false);


### PR DESCRIPTION
… internal `isSkipped` functionality