### PR TITLE
feature/clear-context-after-create-appointment

### DIFF
--- a/src/pages/confirm-appointment.tsx
+++ b/src/pages/confirm-appointment.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Button, Col, Container, Form, Row } from 'react-bootstrap';
 
 import { accountService, appointmentService } from '@/lib/services';
@@ -8,9 +8,9 @@ import useFlags from '@/hooks/use-flags';
 import useAccount from '@/hooks/use-account';
 import AsyncPage from '@/components/async-page';
 import InputHelper from '@/components/input-helper';
+import { buildQueryParamUrl } from '@/lib/utils';
 
 const ConfirmAppointment = () => {
-	const navigate = useNavigate();
 	const [searchParams] = useSearchParams();
 	const promptForPhoneNumber = searchParams.get('promptForPhoneNumber') === 'true';
 	const providerId = searchParams.get('providerId') ?? '';
@@ -142,18 +142,10 @@ const ConfirmAppointment = () => {
 				})
 				.fetch();
 
-			navigate(`/my-calendar?appointmentId=${response.appointment.appointmentId}`, {
-				state: {
-					successBooking: true,
-					emailAddress: response.account.emailAddress,
-				},
-			});
-
-			addFlag({
-				variant: 'success',
-				title: 'Your appointment is reserved',
-				description: `We'll see you ${response.appointment.startTimeDescription}`,
-				actions: [],
+			window.location.href = buildQueryParamUrl('/my-calendar', {
+				appointmentId: response.appointment.appointmentId,
+				successBooking: String(true),
+				...(response.account.emailAddress && { emailAddress: response.account.emailAddress }),
 			});
 		} catch (error) {
 			handleError(error);

--- a/src/pages/ehr-lookup.tsx
+++ b/src/pages/ehr-lookup.tsx
@@ -29,6 +29,7 @@ import { ReactComponent as ProfileIcon } from '@/assets/icons/profile.svg';
 import useHandleError from '@/hooks/use-handle-error';
 import { useCobaltTheme } from '@/jss/theme';
 import HeroContainer from '@/components/hero-container';
+import { buildQueryParamUrl } from '@/lib/utils';
 
 type StepProps = {
 	onNext: (values: Partial<EpicPatientData>) => void;
@@ -175,12 +176,10 @@ const EhrLookup: FC = () => {
 			setSelectedProvider(undefined);
 			setSelectedTimeSlot(undefined);
 
-			navigate(`/my-calendar?appointmentId=${appointment.appointmentId}`, {
-				replace: true,
-				state: {
-					successBooking: true,
-					emailAddress: response.account.emailAddress,
-				},
+			window.location.href = buildQueryParamUrl('/my-calendar', {
+				appointmentId: appointment.appointmentId,
+				successBooking: String(true),
+				...(response.account.emailAddress && { emailAddress: response.account.emailAddress }),
 			});
 		} catch (e) {
 			handleError(e);

--- a/src/pages/my-calendar.tsx
+++ b/src/pages/my-calendar.tsx
@@ -1,5 +1,5 @@
 import React, { FC, useState, useCallback, useEffect, useMemo, createRef, RefObject, useLayoutEffect } from 'react';
-import { useLocation, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { Container, Row, Col } from 'react-bootstrap';
 
 import AsyncPage from '@/components/async-page';
@@ -19,16 +19,21 @@ interface PendingCancellationModel {
 
 const MyCalendar: FC = () => {
 	const handleError = useHandleError();
-	const location = useLocation();
+
 	const [searchParams] = useSearchParams();
-	const appointmentId = searchParams.get('appointmentId') || '';
-	const groupSessionReservationId = searchParams.get('groupSessionReservationId') || '';
-	const action = searchParams.get('action') || '';
+	const appointmentId = useMemo(() => searchParams.get('appointmentId') ?? '', [searchParams]);
+	const groupSessionReservationId = useMemo(
+		() => searchParams.get('groupSessionReservationId') ?? '',
+		[searchParams]
+	);
+	const successBooking = useMemo(() => searchParams.get('successBooking') ?? '', [searchParams]);
+	const emailAddress = useMemo(() => searchParams.get('emailAddress') ?? '', [searchParams]);
+	const action = useMemo(() => searchParams.get('action') ?? '', [searchParams]);
+
 	const [isCancelling, setIsCancelling] = useState(false);
 	const [pendingCancellation, setPendingCancellation] = useState<PendingCancellationModel | undefined>(undefined);
 	const [showConfirmCancelModal, setShowConfirmCancelModal] = useState<boolean>(false);
 	const [calendarEventGroups, setCalendarEventGroups] = useState<CalendarEventGroupsModel[]>([]);
-	const locationState = (location.state as { successBooking?: boolean; emailAddress?: string }) || {};
 
 	const eventRefs = useMemo(
 		() =>
@@ -146,12 +151,11 @@ const MyCalendar: FC = () => {
 			</HeroContainer>
 
 			<div className="pb-8">
-				{locationState?.successBooking ? (
+				{successBooking ? (
 					<HeroContainer className="bg-success">
-						{locationState?.emailAddress ? (
+						{emailAddress ? (
 							<h5 className="text-center text-light mb-0">
-								Your session is reserved and we have sent a confirmation to{' '}
-								{locationState?.emailAddress}.
+								Your session is reserved and we have sent a confirmation to {emailAddress}.
 							</h5>
 						) : (
 							<h5 className="text-center mb-0">Your appointment was reserved.</h5>


### PR DESCRIPTION
convert my-calendar locationState usage to searchParams, manually navigate after confirming appointment to ensure contexts are cleared and reset