### PR TITLE
Prefer `npm ci` to `npm install` for Docker so we rely on `package-lo…

### DIFF
--- a/docker/Dockerfile.employee
+++ b/docker/Dockerfile.employee
@@ -25,6 +25,6 @@ COPY --chown=appuser:appuser . /home/appuser/app/
 
 WORKDIR /home/appuser/app
 
-RUN npm install && npm run build
+RUN npm ci && npm run build
 
 CMD ["sh", "-c", "npm run start"]


### PR DESCRIPTION
…ck.json` when building our FE images