### PR TITLE
fix `HeaderUnauthenticated`

### DIFF
--- a/src/components/header-unauthenticated.tsx
+++ b/src/components/header-unauthenticated.tsx
@@ -84,7 +84,7 @@ const HeaderUnauthenticated = ({ hideSignInButton }: HeaderUnauthenticatedProps)
 					</Button>
 				)}
 
-				{institution.epicFhirEnabled && <InCrisisHeaderButton className="ms-2" />}
+				{institution?.epicFhirEnabled && <InCrisisHeaderButton className="ms-2" />}
 			</div>
 		</header>
 	);


### PR DESCRIPTION
`institution` may fail to load, breaking the header rendering