### PR TITLE
passthrough react nodes to `NoData`

### DIFF
--- a/src/components/no-data.tsx
+++ b/src/components/no-data.tsx
@@ -1,6 +1,6 @@
 import { createUseThemedStyles } from '@/jss/theme';
 import classNames from 'classnames';
-import React, { ReactElement } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { Button } from 'react-bootstrap';
 import { ButtonVariant } from 'react-bootstrap/esm/types';
 
@@ -24,7 +24,7 @@ export interface NoDataAction {
 export interface NoDataProps {
 	illustration?: ReactElement;
 	title: string;
-	description?: string;
+	description?: string | ReactNode;
 	actions: NoDataAction[];
 	className?: string;
 }

--- a/src/components/support-mhp-shell.tsx
+++ b/src/components/support-mhp-shell.tsx
@@ -15,7 +15,7 @@ import { useNavigate } from 'react-router-dom';
 interface SupportMentalHealthProvidersShellProps {
 	myChartAuthUrlState: [string, React.Dispatch<React.SetStateAction<string>>];
 	renderFeatureDetail: (featureDetail: InstitutionFeature) => ReactNode;
-	connectDescription: string;
+	connectDescription: ReactNode;
 	connectActions: NoDataAction[];
 }
 


### PR DESCRIPTION
supporting links and other markup