### PR TITLE
feature/crop-modal-enhancements

### DIFF
--- a/src/components/flags.tsx
+++ b/src/components/flags.tsx
@@ -22,8 +22,8 @@ const useStyles = createUseThemedStyles((theme) => ({
 	flagsOuter: {
 		left: 48,
 		bottom: 48,
-		// ridiculous number to be above bootstrap offCanvas element
-		zIndex: 1041,
+		// ridiculous number to be above bootstrap offCanvas element and modal
+		zIndex: 1056,
 		width: 400,
 		position: 'fixed',
 		'& .flag': {

--- a/src/components/session-crop-modal.tsx
+++ b/src/components/session-crop-modal.tsx
@@ -4,9 +4,9 @@ import ReactCrop from 'react-image-crop';
 
 import { ReactComponent as InfoIcon } from '@/assets/icons/icon-info-fill.svg';
 import 'react-image-crop/dist/ReactCrop.css';
-import useHandleError from '@/hooks/use-handle-error';
 import { createUseThemedStyles } from '@/jss/theme';
 import useTrackModalView from '@/hooks/use-track-modal-view';
+import useFlags from '@/hooks/use-flags';
 
 function getCroppedImageAsBlob(image: HTMLImageElement, crop: any): Promise<Blob> | undefined {
 	const canvas = document.createElement('canvas');
@@ -38,7 +38,10 @@ function getCroppedImageAsBlob(image: HTMLImageElement, crop: any): Promise<Blob
 		canvas.toBlob(
 			(blob) => {
 				if (!blob) {
-					return reject({ code: 400, message: 'Error converting crop to blob.' });
+					return reject({
+						code: 400,
+						message: 'Error cropping image, please recrop your image and try again.',
+					});
 				}
 
 				resolve(blob);
@@ -68,7 +71,7 @@ interface SessionCropModalProps extends ModalProps {
 
 const SessionCropModal: FC<SessionCropModalProps> = ({ imageSource, onSave, onHide, ...props }) => {
 	useTrackModalView('SessionCropModal', props.show);
-	const handleError = useHandleError();
+	const { addFlag } = useFlags();
 	const imageRef = useRef<HTMLImageElement>();
 	const classes = useSessionCropModalStyles();
 	const [crop, setCrop] = useState({
@@ -100,7 +103,12 @@ const SessionCropModal: FC<SessionCropModalProps> = ({ imageSource, onSave, onHi
 
 			onSave(blob);
 		} catch (error) {
-			handleError(error);
+			addFlag({
+				variant: 'danger',
+				title: 'Error',
+				description: (error as any).message,
+				actions: [],
+			});
 		}
 	}
 

--- a/src/components/session-crop-modal.tsx
+++ b/src/components/session-crop-modal.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useRef, useState, useCallback, useEffect } from 'react';
+import React, { FC, useRef, useState, useCallback } from 'react';
 import { ModalProps, Modal, Button } from 'react-bootstrap';
 import ReactCrop from 'react-image-crop';
 
@@ -114,6 +114,14 @@ const SessionCropModal: FC<SessionCropModalProps> = ({ imageSource, onSave, onHi
 		}, 0);
 	}, []);
 
+	const handleEntered = useCallback(() => {
+		setCrop({
+			width: 90,
+			aspect: 16 / 9,
+			unit: '%' as '%',
+		});
+	}, []);
+
 	const handleHide = useCallback(() => {
 		if (isDragging) {
 			return;
@@ -125,7 +133,13 @@ const SessionCropModal: FC<SessionCropModalProps> = ({ imageSource, onSave, onHi
 	}, [isDragging, onHide]);
 
 	return (
-		<Modal {...props} onHide={handleHide} dialogClassName={classes.sessionCropModal} centered>
+		<Modal
+			{...props}
+			onEntered={handleEntered}
+			onHide={handleHide}
+			dialogClassName={classes.sessionCropModal}
+			centered
+		>
 			<Modal.Header closeButton>
 				<Modal.Title>crop image</Modal.Title>
 			</Modal.Header>
@@ -144,7 +158,7 @@ const SessionCropModal: FC<SessionCropModalProps> = ({ imageSource, onSave, onHi
 				</div>
 			</Modal.Body>
 			<Modal.Footer className="d-flex justify-content-end">
-				<Button variant="outline-primary" size="sm" onClick={props.onHide}>
+				<Button variant="outline-primary" size="sm" onClick={handleHide}>
 					Cancel
 				</Button>
 				<Button variant="primary" size="sm" className="ms-2" onClick={handleOnSaveButtonClick}>


### PR DESCRIPTION
don't allow modal to close if user is actively cropping
reset the crop zone when the modal enters
if the crop is unusable, show a flag with a message instead of the error modal